### PR TITLE
amends album/project auth logic

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix-97/unsecured-album-is-visible-when-full-of-secured-projects
 
     paths:
       - package.json

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix-97/unsecured-album-is-visible-when-full-of-secured-projects
 
     paths:
       - package.json

--- a/app/modules/crypto/is-secured.ts
+++ b/app/modules/crypto/is-secured.ts
@@ -1,0 +1,8 @@
+import type { SecuredEncrypted } from './types/secured-encrypted';
+import type { WithEncryptedSecurity } from './types/with-encrypted-security';
+
+export function isSecured(
+  entity: Partial<WithEncryptedSecurity>
+): entity is SecuredEncrypted {
+  return !!entity.isSecure && !!entity.security;
+}

--- a/app/modules/crypto/types/secured-encrypted.ts
+++ b/app/modules/crypto/types/secured-encrypted.ts
@@ -1,0 +1,7 @@
+import type { WithEncryptedPassword } from '~/modules/crypto/types/with-encrypted-password';
+import type { WithEncryptedSecurity } from './with-encrypted-security';
+
+export interface SecuredEncrypted extends WithEncryptedSecurity {
+  isSecure: true;
+  security: WithEncryptedPassword;
+}

--- a/app/modules/crypto/types/with-encrypted-security.ts
+++ b/app/modules/crypto/types/with-encrypted-security.ts
@@ -1,6 +1,6 @@
 import type { WithEncryptedPassword } from '~/modules/crypto/types/with-encrypted-password';
 
-export type WithEncryptedSecurity = {
+export interface WithEncryptedSecurity {
   isSecure: boolean;
   security: WithEncryptedPassword | null;
-};
+}

--- a/app/routes/$user/albums/$album/index.tsx
+++ b/app/routes/$user/albums/$album/index.tsx
@@ -12,7 +12,6 @@ import type { ActionFunction, LoaderFunction } from '@remix-run/node';
 import { json, redirect } from '@remix-run/node';
 import { Link, useLoaderData } from '@remix-run/react';
 import { castArray } from 'lodash';
-import * as React from 'react';
 import { z } from 'zod';
 import { AlbumProjectsForm } from '~/modules/albums/components/album-projects-form';
 import { getAlbumPath } from '~/modules/albums/get-album-path';
@@ -23,6 +22,7 @@ import { Breadcrumbs } from '~/modules/common/breadcrumbs';
 import { EditButton } from '~/modules/common/edit-button';
 import PageLayout from '~/modules/common/page-layout';
 import { TogglableContent } from '~/modules/common/togglable-content';
+import { isSecured } from '~/modules/crypto/is-secured';
 import type { WithEncryptedSecurity } from '~/modules/crypto/types/with-encrypted-security';
 import { ProjectCard } from '~/modules/projects/components/project-card';
 import { Projects } from '~/modules/projects/components/project-list';
@@ -213,9 +213,14 @@ export default function AlbumScreen() {
                 />
               );
 
+              const projectsToDisplay =
+                isCurrentUser || isSecured(album)
+                  ? album.projects
+                  : album.projects.filter(({ isSecure }) => !isSecure);
+
               const projectList = (
                 <Projects>
-                  {album.projects.map((project) => (
+                  {projectsToDisplay.map((project) => (
                     <ProjectCard
                       key={project.id}
                       project={project}
@@ -243,7 +248,7 @@ export default function AlbumScreen() {
                 </div>
               );
 
-              const displayProjects = album.projects.length ? (
+              const displayProjects = projectsToDisplay.length ? (
                 projectList
               ) : isCurrentUser ? (
                 addProjectButton


### PR DESCRIPTION
fixes bug with secured project is not being authorized if requested through unsecured album

Resolves #97

---
### Album / Project auth logic:

#### If album _is not_ secured:

If user tries to acces project by album link `/[user_nickname]/albums/[album_identifier]/[project_identifier]`
- user will be prompted to enter _project_-specific password
- user will be able to access this project by direct project link `/[user_nickname]/[project_identifier]`
- user will be able to access this project throught any _non-secured_ album `/[user_nickname]/albums/[album_identifier]/[project_identifier]`
- user will **NOT** be able to access this project throught any _secured_ album unless they enter _album_-specific password

#### If album _is_ secured:

If user tries to acces project by album link `/[user_nickname]/albums/[album_identifier]/[project_identifier]`
- user will be able to access this or any other project that is contained in the album 
- user will be prompted to enter _album_-specific password
- user will **NOT** be able to access this project by direct project link `/[user_nickname]/[project_identifier]` unless they enter _album_-specific password
- user will **NOT** be able to access this project throught any _non-secured_ album `/[user_nickname]/albums/[album_identifier]/[project_identifier]`  unless they enter _album_-specific password
